### PR TITLE
Handle protos without a package

### DIFF
--- a/protoc-gen-java-optional-test/src/test/resources/no-package-type.proto
+++ b/protoc-gen-java-optional-test/src/test/resources/no-package-type.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.test.datatypes";
+
+message NoPackageTestMessage {
+  message NestedTestMessage {
+    string string = 1;
+    optional string optional_string = 2;
+  }
+}
+

--- a/protoc-gen-java-optional/src/main/java/org/grpcmock/protoc/plugin/OptionalGenerator.java
+++ b/protoc-gen-java-optional/src/main/java/org/grpcmock/protoc/plugin/OptionalGenerator.java
@@ -104,7 +104,7 @@ public class OptionalGenerator extends Generator {
       String javaPackage
   ) {
     String filePath = javaPackage.replace(".", DIR_SEPARATOR) + DIR_SEPARATOR + fileName + JAVA_EXTENSION;
-    String fullMethodName = protoPackage + "." + messageDescriptor.getName();
+    String fullMethodName = (protoPackage.isEmpty() ? "" : (protoPackage + ".")) + messageDescriptor.getName();
 
     return Stream.concat(
         handleSingleMessage(messageDescriptor, filePath, fullMethodName),


### PR DESCRIPTION
Fixes the following error when a proto has no package

```
org/test/datatypes/NoPackageTestMessage.java: insertion point "class_scope:.NoPackageTestMessage.NestedTestMessage" not found.
```